### PR TITLE
(FIX): msg_rand improperly called rdmindex

### DIFF
--- a/handshake/version.h
+++ b/handshake/version.h
@@ -4,6 +4,6 @@
 // the version identifier of the version is a n characters random generated string
 // the final string wll be generated with the final version
 #define __ARPNET_VER_ID_LEN 37
-#define __ARPNET_VER_ID "861xd46v16DV1GX4dg1b486j14n86vg14bv6"
-/*	Last modified Feb-05-2021	*/
+#define __ARPNET_VER_ID "p48fe17h83CA5DD2hs2hw53b52o24fe72de7"
+/*	Last modified Feb-09-2021	*/
 #endif

--- a/message/message.c
+++ b/message/message.c
@@ -76,7 +76,7 @@ int msg_all_visited( message_t* msg )
 }
 
 // choose randomly an unvisited node, without marking the returned index in the message
-node_id msg_rand( message_t* msg )
+int msg_rand( message_t* msg )
 {
     if( bv_all_marked( &msg->vis_set ) ) return -1;
 
@@ -100,7 +100,7 @@ node_id msg_rand( message_t* msg )
     // get the random index
     int n = 0;
     if( max > 1 )
-        n = rdmindex(0, max);
+        n = rdmindex(0, max-1);
 
     return idx[n];
 }

--- a/message/message.h
+++ b/message/message.h
@@ -143,10 +143,10 @@ int msg_all_visited( message_t* msg );
 *	msg - The message within to choose the next node 
 *
 * Return
-*	idx[n] - ID of the randomly chosen node
+*	idx[n] - ID of the randomly chosen node (or an error code)
 *	
 ****************************************************************************/
-node_id msg_rand( message_t* msg );
+int msg_rand( message_t* msg );
 
 
 /************************************************************************//**

--- a/misc/random_index.c
+++ b/misc/random_index.c
@@ -11,7 +11,7 @@ int rdmindex(int min , int max)
 	// this piece discards values of 'r' which would cause non-uniformity in
 	// the subsequent 'modulo' operation (since RAND_MAX is generally not abort
 	// multiple of our required range.
-	while( (r = rand()) > RAND_MAX - (RAND_MAX - (range-1) )%range ){}
+	while( (r = rand()) > (RAND_MAX - (RAND_MAX - (range-1) )%range) ){}
       
 	return min + r%range;
 }


### PR DESCRIPTION
Range was (0, max) instead of (0, max-1), causing errors in the retrieval of a next random node.