### PR TITLE
(Important FIX) RURZ placeholder IP to 255.0.0.0

### DIFF
--- a/handshake/version.h
+++ b/handshake/version.h
@@ -4,6 +4,6 @@
 // the version identifier of the version is a n characters random generated string
 // the final string wll be generated with the final version
 #define __ARPNET_VER_ID_LEN 37
-#define __ARPNET_VER_ID "p48fe17h83CA5DD2hs2hw53b52o24fe72de7"
+#define __ARPNET_VER_ID "f71gn41n02FE4BA1lj7sw53q15l74kf11as9"
 /*	Last modified Feb-09-2021	*/
 #endif

--- a/statistics/statistics.c
+++ b/statistics/statistics.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 
-char* RURZ_IP_STR = "0.0.0.0";
+char* RURZ_IP_STR = "255.0.0.0";
 // int RURZ_PORTNO = -1;
 
 // initialize stat message


### PR DESCRIPTION
Previous placeholder IP was 0.0.0.0, which caused weird loopback behaviours in some unforeseen scenarios.